### PR TITLE
Do not recalculate bounds if provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "url": "https://github.com/mikolalysenko/snap-points-2d/issues"
   },
   "homepage": "https://github.com/mikolalysenko/snap-points-2d#readme",
-  "dependencies": {
-    "typedarray-pool": "^1.1.0"
-  },
   "devDependencies": {
+    "typedarray-pool": "^1.1.0",
     "almost-equal": "^1.0.0",
     "gauss-random": "^1.0.1",
     "tape": "^4.2.0"
+  },
+  "dependencies": {
+    "array-bounds": "^1.0.1"
   }
 }

--- a/snap.js
+++ b/snap.js
@@ -5,6 +5,36 @@ var getBounds = require('array-bounds')
 
 module.exports = snapPoints
 
+function partition(points, ids, start, end, lox, loy, hix, hiy) {
+  var mid = start
+  for(var i=start; i<end; ++i) {
+    var x  = points[2*i]
+    var y  = points[2*i+1]
+    var s  = ids[i]
+    if(lox <= x && x <= hix &&
+       loy <= y && y <= hiy) {
+      if(i === mid) {
+        mid += 1
+      } else {
+        points[2*i]     = points[2*mid]
+        points[2*i+1]   = points[2*mid+1]
+        ids[i]          = ids[mid]
+        points[2*mid]   = x
+        points[2*mid+1] = y
+        ids[mid]        = s
+        mid += 1
+      }
+    }
+  }
+  return mid
+}
+
+function SnapInterval(pixelSize, offset, count) {
+  this.pixelSize  = pixelSize
+  this.offset     = offset
+  this.count      = count
+}
+
 function snapPoints(points, ids, weights, bounds) {
   var n = points.length >>> 1
   if(n < 1) {
@@ -20,7 +50,7 @@ function snapPoints(points, ids, weights, bounds) {
   }
 
   // empty bounds or invalid bounds are considered as undefined and require recalc
-  if (!bounds.length || bounds[0] >= bounds[2] || bounds[1] >= bounds[3]) {
+  if (!bounds.length || bounds.length < 4 || bounds[0] >= bounds[2] || bounds[1] >= bounds[3]) {
     var b = getBounds(points, 2)
 
     if(b[0] === b[2]) {
@@ -109,34 +139,4 @@ function snapPoints(points, ids, weights, bounds) {
   lod.push(new SnapInterval(diam * Math.pow(0.5, level+1), 0, prevOffset))
 
   return lod
-}
-
-function partition(points, ids, start, end, lox, loy, hix, hiy) {
-  var mid = start
-  for(var i=start; i<end; ++i) {
-    var x  = points[2*i]
-    var y  = points[2*i+1]
-    var s  = ids[i]
-    if(lox <= x && x <= hix &&
-       loy <= y && y <= hiy) {
-      if(i === mid) {
-        mid += 1
-      } else {
-        points[2*i]     = points[2*mid]
-        points[2*i+1]   = points[2*mid+1]
-        ids[i]          = ids[mid]
-        points[2*mid]   = x
-        points[2*mid+1] = y
-        ids[mid]        = s
-        mid += 1
-      }
-    }
-  }
-  return mid
-}
-
-function SnapInterval(pixelSize, offset, count) {
-  this.pixelSize  = pixelSize
-  this.offset     = offset
-  this.count      = count
 }

--- a/snap.js
+++ b/snap.js
@@ -11,11 +11,16 @@ function snapPoints(points, ids, weights, bounds) {
     return []
   }
 
+  if (!ids) ids = Array(n)
+  if (!weights) weights = Array(n)
+  if (!bounds) bounds = []
+
   for(var i=0; i<n; ++i) {
     ids[i] = i
   }
 
-  if (!bounds || !bounds.length) {
+  // empty bounds or infinite bounds are considered as undefined bounds
+  if (!bounds.length || bounds[0] === -Infinity || bounds[1] === -Infinity || bounds[2] === Infinity || bounds[3] === Infinity) {
     var b = getBounds(points, 2)
 
     if(b[0] === b[2]) {

--- a/snap.js
+++ b/snap.js
@@ -20,7 +20,7 @@ function snapPoints(points, ids, weights, bounds) {
   }
 
   // empty bounds or invalid bounds are considered as undefined and require recalc
-  if (!bounds.length || bounds[0] >= bounds[1] || bounds[2] <= bounds[3]) {
+  if (!bounds.length || bounds[0] >= bounds[2] || bounds[1] >= bounds[3]) {
     var b = getBounds(points, 2)
 
     if(b[0] === b[2]) {

--- a/snap.js
+++ b/snap.js
@@ -19,8 +19,8 @@ function snapPoints(points, ids, weights, bounds) {
     ids[i] = i
   }
 
-  // empty bounds or infinite bounds are considered as undefined bounds
-  if (!bounds.length || bounds[0] === -Infinity || bounds[1] === -Infinity || bounds[2] === Infinity || bounds[3] === Infinity) {
+  // empty bounds or invalid bounds are considered as undefined and require recalc
+  if (!bounds.length || bounds[0] >= bounds[1] || bounds[2] <= bounds[3]) {
     var b = getBounds(points, 2)
 
     if(b[0] === b[2]) {

--- a/snap.js
+++ b/snap.js
@@ -24,12 +24,17 @@ function snapPoints(points, ids, weights, bounds) {
     if(b[1] === b[3]) {
       b[3] += 1
     }
+
+    bounds[0] = b[0]
+    bounds[1] = b[1]
+    bounds[2] = b[2]
+    bounds[3] = b[3]
   }
 
-  var lox = bounds[0] = b[0]
-  var loy = bounds[1] = b[1]
-  var hix = bounds[2] = b[2]
-  var hiy = bounds[3] = b[3]
+  var lox = bounds[0]
+  var loy = bounds[1]
+  var hix = bounds[2]
+  var hiy = bounds[3]
 
   //Calculate diameter
   var scaleX = 1.0 / (hix - lox)

--- a/snap.js
+++ b/snap.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var pool = require('typedarray-pool')
-
 var sortLevels = require('./lib/sort')
 
 module.exports = snapPoints
@@ -73,7 +71,7 @@ function snapPoints(points, ids, weights, bounds) {
   bounds[2] = hix
   bounds[3] = hiy
 
-  var levels = pool.mallocInt32(n)
+  var levels = new Int32Array(n)
   var ptr = 0
 
   function snapRec(x, y, diam, start, end, level) {
@@ -132,7 +130,6 @@ function snapPoints(points, ids, weights, bounds) {
   }
 
   lod.push(new SnapInterval(diam * Math.pow(0.5, level+1), 0, prevOffset))
-  pool.free(levels)
 
   return lod
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ tape('snap-points-2d', function(t) {
     var npoints   = points.slice()
     var ids       = new Array(numPoints)
     var weights   = new Array(numPoints)
-    var bounds    = [0,0,0,0]
+    var bounds    = []
 
     var scales = snap(npoints, ids, weights, bounds)
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ var tape = require('tape')
 var snap = require('../snap')
 var approxEqual = require('almost-equal')
 
+
 tape('snap-points-2d', function(t) {
 
   function verifySnap(points) {

--- a/test/test.js
+++ b/test/test.js
@@ -93,3 +93,32 @@ k_loop:
 
   t.end()
 })
+
+
+tape('no arguments', function (t) {
+  var levels = snap([0,0, 1,1, 2,2])
+
+  t.end()
+})
+
+tape('larger bounds', function (t) {
+  var pos = [0,0, 1,1, 2,2, 3,3, 4,4]
+
+  var levels = snap(pos.slice(), [], [], [0,0,4,4])
+  t.deepEqual(levels, [
+      {pixelSize: 2, offset: 4, count: 1},
+      {pixelSize: 1, offset: 2, count: 2},
+      {pixelSize: 0.5, offset: 0, count: 2}
+  ])
+
+  var levels2 = snap(pos.slice(), [], [], [0,0,40,40])
+  t.deepEqual(levels2, [
+    {pixelSize: 20, offset: 4, count: 1},
+    {pixelSize: 10, offset: 3, count: 1},
+    {pixelSize: 5, offset: 2, count: 1},
+    {pixelSize: 2.5, offset: 1, count: 1},
+    {pixelSize: 1.25, offset: 0, count: 1}
+  ])
+
+  t.end()
+})


### PR DESCRIPTION
If we want to calc snapping on a subset of some larger data, we may want to provide actual bounds rather than calculate it.
Also [array-bounds](https://github.com/dfcreative/array-bounds) turns out to be a bit faster.